### PR TITLE
Fix radio gender filter selection

### DIFF
--- a/src/components/filters/InputRadioType2.jsx
+++ b/src/components/filters/InputRadioType2.jsx
@@ -19,7 +19,7 @@ const InputRadioType2 = ({ data }) => {
         name="gender"
         value={data}
         className="invisible"
-        selected={gender === data}
+        checked={gender === data}
         onChange={(e) => applyFilters(e.target.name, e.target.value)}
       />
     </label>


### PR DESCRIPTION
## Summary
- fix `InputRadioType2` to use the `checked` attribute so the gender radio button tracks state properly

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6847abc2cf808327969016e95995c35d